### PR TITLE
Bugfixes on "waiting for Liveness and Readiness" step

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -97,39 +97,39 @@ func Delete(chart string, dryRun bool) {
 // UpgradeWithValues ...
 func UpgradeWithValues(namespace string, release string, chartName string, chartPath string, resetValues bool, reuseValues bool, valueFiles []string, valuesSet string, force bool, dryRun bool, debug bool) {
 	var myargs []string = []string{"upgrade", "--install", release, chartPath, "--namespace", namespace, "--set", valuesSet}
-    for _, v := range valueFiles {
-        myargs = append(myargs, "-f")
-        myargs = append(myargs, v)
-    }
+	for _, v := range valueFiles {
+		myargs = append(myargs, "-f")
+		myargs = append(myargs, v)
+	}
 
-    if resetValues {
-        myargs = append(myargs, "--reset-values")
-    }
+	if resetValues {
+		myargs = append(myargs, "--reset-values")
+	}
 
-    if reuseValues {
-        myargs = append(myargs, "--reuse-values")
-    }
+	if reuseValues {
+		myargs = append(myargs, "--reuse-values")
+	}
 
-    if force {
-        myargs = append(myargs, "--force")
-    }
+	if force {
+		myargs = append(myargs, "--force")
+	}
 
 	if dryRun {
-        myargs = append(myargs, "--dry-run")
-    }
+		myargs = append(myargs, "--dry-run")
+	}
 
-    if debug {
-        myargs = append(myargs, "--debug")
-        fmt.Printf("[spray] running helm command for \"%s\": %v\n", release, myargs)
-    }
+	if debug {
+		myargs = append(myargs, "--debug")
+		fmt.Printf("[spray] running helm command for \"%s\": %v\n", release, myargs)
+	}
 
 	cmd := exec.Command("helm", myargs...)
-    if debug {
-	    cmd.Stdout = os.Stdout
-    } else {
-	    cmdOutput := &bytes.Buffer{}
-    	cmd.Stdout = cmdOutput
-    }
+	if debug {
+		cmd.Stdout = os.Stdout
+	} else {
+		cmdOutput := &bytes.Buffer{}
+		cmd.Stdout = cmdOutput
+	}
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
@@ -148,18 +148,18 @@ func Upgrade(namespace string, chart string, chartPath string, valuesSet string,
 		myargs = []string{"upgrade", "--install", "--namespace", namespace, "--set", chart + ".enabled=true," + valuesSet, chart, chartPath}
 	}
 
-    if debug {
-        myargs = append(myargs, "--debug")
-        fmt.Printf("[spray] running command: %v\n", myargs)
-    }
+	if debug {
+		myargs = append(myargs, "--debug")
+		fmt.Printf("[spray] running command: %v\n", myargs)
+	}
 
 	cmd := exec.Command("helm", myargs...)
-    if debug {
-        cmd.Stdout = os.Stdout
-    } else {
-	    cmdOutput := &bytes.Buffer{}
-    	cmd.Stdout = cmdOutput
-    }
+	if debug {
+		cmd.Stdout = os.Stdout
+	} else {
+		cmdOutput := &bytes.Buffer{}
+		cmd.Stdout = cmdOutput
+	}
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -14,7 +14,6 @@ package kubectl
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 )
@@ -90,7 +89,8 @@ func IsStatefulSetUpToDate(deployment string, namespace string) bool {
 func getDesired(k8stype string, namespace string, deployment string) string {
 	desired, err := exec.Command("kubectl", "--namespace", namespace, "get", k8stype, deployment, "-o=jsonpath='{.spec.replicas}'").Output()
 	if err != nil {
-		log.Fatal(err)
+		// Cannot make the difference between an error when calling kubectl and no corresponding resource found. Return "0" in any case.
+		return "0"
 	}
 	return string(desired)
 }
@@ -98,7 +98,8 @@ func getDesired(k8stype string, namespace string, deployment string) string {
 func getReady(k8stype string, namespace string, deployment string) string {
 	ready, err := exec.Command("kubectl", "--namespace", namespace, "get", k8stype, deployment, "-o=jsonpath='{.status.readyReplicas}'").Output()
 	if err != nil {
-		log.Fatal(err)
+		// Cannot make the difference between an error when calling kubectl and no corresponding resource found. Return "0" in any case.
+		return "0"
 	}
 	return string(ready)
 }
@@ -106,7 +107,8 @@ func getReady(k8stype string, namespace string, deployment string) string {
 func getUpdated(k8stype string, namespace string, deployment string) string {
 	updated, err := exec.Command("kubectl", "--namespace", namespace, "get", k8stype, deployment, "-o=jsonpath='{.status.updatedReplicas}'").Output()
 	if err != nil {
-		log.Fatal(err)
+		// Cannot make the difference between an error when calling kubectl and no corresponding resource found. Return "0" in any case.
+		return "0"
 	}
 	return string(updated)
 }


### PR DESCRIPTION
This Pull Request addresses issues https://github.com/gemalto/helm-spray/issues/10, https://github.com/gemalto/helm-spray/issues/11, and https://github.com/gemalto/helm-spray/issues/12.

Note that the "waiting for Liveness and Readiness" step still checks the Deployment status only. This means that:
- It is not properly waiting the completion of the upgrade or execution of Statefulsets and Jobs
- If the targeted sub-chart only contains hooks, then `helm spray` raises an error, as referenced in https://github.com/gemalto/helm-spray/issues/13 (`helm` issue)
