### PR TITLE
Enhance "wait liveness and readiness" and create capability to prefix releases names

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,18 +76,24 @@ Note: if an alias is set for a sub-chart, then this is this alias that should be
 ### Flags:
 
 ```
-      --debug              enable helm debug output (also include spray verbose output)
-      --dry-run            simulate a spray
-      --force              force resource update through delete/recreate if needed
-  -h, --help               help for helm
-  -n, --namespace string   namespace to spray the chart into. (default "default")
-      --reset-values       when upgrading, reset the values to the ones built into the chart
-      --reuse-values       when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f. If '--reset-values' is specified, this is ignored.
-      --set string         set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
-  -t, --target strings     specify the subchart to target (can specify multiple). If --target is not specified, all subcharts are targeted
-  -f, --values strings     specify values in a YAML file or a URL (can specify multiple)
-      --verbose            enable spray verbose output
-      --version string     specify the exact chart version to install. If this is not specified, the latest version is installed
+      --debug                            enable helm debug output (also include spray verbose output)
+      --dry-run                          simulate a spray
+      --force                            force resource update through delete/recreate if needed
+  -h, --help                             help for helm
+  -n, --namespace string                 namespace to spray the chart into. (default "default")
+      --prefix-releases string           prefix the releases by the given string, resulting into releases names formats:
+                                             "<prefix>-<chart name or alias>"
+                                         Allowed characters are a-z A-Z 0-9 and -
+      --prefix-releases-with-namespace   prefix the releases by the name of the namespace, resulting into releases names formats:
+                                             "<namespace>-<chart name or alias>"
+      --reset-values                     when upgrading, reset the values to the ones built into the chart
+      --reuse-values                     when upgrading, reuse the last release's values and merge in any overrides from the command line via '--set' and '-f'.
+                                         If '--reset-values' is specified, this is ignored.
+      --set string                       set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+  -t, --target strings                   specify the subchart to target (can specify multiple). If '--target' is not specified, all subcharts are targeted
+  -f, --values strings                   specify values in a YAML file or a URL (can specify multiple)
+      --verbose                          enable spray verbose output
+      --version string                   specify the exact chart version to install. If this is not specified, the latest version is installed
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Note: if an alias is set for a sub-chart, then this is this alias that should be
 ### Flags:
 
 ```
-      --debug              enable verbose output
+      --debug              enable helm debug output (also include spray verbose output)
       --dry-run            simulate a spray
       --force              force resource update through delete/recreate if needed
   -h, --help               help for helm
@@ -86,6 +86,7 @@ Note: if an alias is set for a sub-chart, then this is this alias that should be
       --set string         set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
   -t, --target strings     specify the subchart to target (can specify multiple). If --target is not specified, all subcharts are targeted
   -f, --values strings     specify values in a YAML file or a URL (can specify multiple)
+      --verbose            enable spray verbose output
       --version string     specify the exact chart version to install. If this is not specified, the latest version is installed
 ```
 

--- a/main.go
+++ b/main.go
@@ -254,10 +254,12 @@ func (p *sprayCmd) spray() error {
 			}
 
 			if dependency.Alias == "" {
-				log(2, "subchart \"%s\" - targeted: %t - weight: %d | corresponding release: \"%s\" - current revision: %s - current status: %s", dependency.Name, dependency.Targeted, dependency.Weight, dependency.CorrespondingReleaseName, currentRevision, currentStatus)
+				log(2, "subchart \"%s\" - targeted: %t - weight: %d", dependency.Name, dependency.Targeted, dependency.Weight)
+				log(3, "corresponding release: \"%s\" - current revision: %s - current status: %s", dependency.CorrespondingReleaseName, currentRevision, currentStatus)
 
 			} else {
-				log(2, "subchart \"%s\" (is alias of \"%s\") - targeted: %t - weight: %d | corresponding release: \"%s\" - current revision: %s - current status: %s", dependency.Alias, dependency.Name, dependency.Targeted, dependency.Weight, dependency.CorrespondingReleaseName, currentRevision, currentStatus)
+				log(2, "subchart \"%s\" (is alias of \"%s\") - targeted: %t - weight: %d", dependency.Alias, dependency.Name, dependency.Targeted, dependency.Weight)
+				log(3, "corresponding release: \"%s\" - current revision: %s - current status: %s", dependency.CorrespondingReleaseName, currentRevision, currentStatus)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"bufio"
 	"strconv"
 	"strings"
 	"time"
@@ -38,6 +39,7 @@ type sprayCmd struct {
 	valuesSet		string
 	force			bool
 	dryRun			bool
+	verbose			bool
 	debug			bool
 }
 
@@ -116,6 +118,8 @@ func newSprayCmd(args []string) *cobra.Command {
 					fmt.Println("You cannot use --version together with chart directory")
 					os.Exit(1)
 				}
+
+				log(1, "fetching chart \"%s\" version %s...", p.chartName, p.chartVersion)
 				helm.Fetch(p.chartName, p.chartVersion)
 			}
 
@@ -133,7 +137,8 @@ func newSprayCmd(args []string) *cobra.Command {
 	f.StringVarP(&p.valuesSet, "set", "", "", "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
 	f.BoolVar(&p.force, "force", false, "force resource update through delete/recreate if needed")
 	f.BoolVar(&p.dryRun, "dry-run", false, "simulate a spray")
-	f.BoolVar(&p.debug, "debug", false, "enable verbose output")
+	f.BoolVar(&p.verbose, "verbose", false, "enable spray verbose output")
+	f.BoolVar(&p.debug, "debug", false, "enable helm debug output (also include spray verbose output)")
 	f.Parse(args)
 
 	// When called through helm, debug mode is transmitted through the HELM_DEBUG envvar
@@ -141,6 +146,9 @@ func newSprayCmd(args []string) *cobra.Command {
 		if "1" == os.Getenv("HELM_DEBUG") {
 			p.debug = true
 		}
+	}
+	if p.debug {
+		p.verbose = true
 	}
 
 	return cmd
@@ -205,25 +213,49 @@ func (p *sprayCmd) spray() error {
 		}
 	}
 
-	// For debug...
-	if p.debug {
+	log(1, "deploying solution chart \"%s\" in namespace \"%s\"", p.chartName, p.namespace)
+	helmReleases := helm.ListAll() //p.namespace)
+
+	if p.verbose {
+		log(1, "subcharts:")
+
 		for _, dependency := range dependencies {
+			currentRevision := "None"
+			currentStatus := "Not deployed"
+			if release, ok := helmReleases[dependency.UsedName]; ok {
+				currentRevision = strconv.Itoa(release.Revision)
+				currentStatus = release.Status
+			}
+
 			if dependency.Alias == "" {
-				fmt.Printf("[spray] subchart: \"%s\" | targeted: %t | weight: %d\n", dependency.Name, dependency.Targeted, dependency.Weight)
+				log(2, "\"%s\" | targeted: %t | weight: %d | current revision: %s | current status: %s", dependency.Name, dependency.Targeted, dependency.Weight, currentRevision, currentStatus)
+
 			} else {
-				fmt.Printf("[spray] subchart: \"%s\" (is alias of: \"%s\") | targeted: %t | weight: %d\n", dependency.Alias, dependency.Name, dependency.Targeted, dependency.Weight)
+				log(2, "\"%s\" (is alias of \"%s\") | targeted: %t | weight: %d | current revision: %s | current status: %s", dependency.Alias, dependency.Name, dependency.Targeted, dependency.Weight, currentRevision, currentStatus)
 			}
 		}
 	}
 
 	for i := 0; i <= getMaxWeight(dependencies); i++ {
 		shouldWait := false
+		firstInWeight := true
+		helmstatusses := make([]helm.HelmStatus, 0)
 
 		// Upgrade the current (targeted) Deployments, following the increasing weight
 		for _, dependency := range dependencies {
 			if dependency.Targeted {
 				if dependency.Weight == i {
-					fmt.Println("[spray] upgrading release: \"" + dependency.UsedName + "\"...")
+					if firstInWeight {
+						log(1, "processing sub-charts of weight %d", dependency.Weight)
+						firstInWeight = false
+					}
+
+					if release, ok := helmReleases[dependency.UsedName]; ok {
+						log(2, "upgrading release \"%s\": going from revision %d (status %s) to %d...", dependency.UsedName, release.Revision, release.Status, release.Revision+1)
+					} else {
+						log(2, "upgrading release \"%s\": deploying first revision...", dependency.UsedName)
+					}
+
 					shouldWait = true
 
 					// Add the "<dependency>.enabled" flags to ensure that only the current chart is to be executed
@@ -238,29 +270,74 @@ func (p *sprayCmd) spray() error {
 					valuesSet = valuesSet + p.valuesSet
 
 					// Upgrade the Deployment
-					helm.UpgradeWithValues(p.namespace, dependency.UsedName, dependency.UsedName, p.chartName, p.resetValues, p.reuseValues, p.valueFiles, valuesSet, p.force, p.dryRun, p.debug)
+					helmstatus := helm.UpgradeWithValues(p.namespace, dependency.UsedName, dependency.UsedName, p.chartName, p.resetValues, p.reuseValues, p.valueFiles, valuesSet, p.force, p.dryRun, p.debug)
 
-					if !p.dryRun {
-						status := helm.GetHelmStatus(dependency.UsedName)
-						if status != "DEPLOYED" {
-							os.Exit(1)
+					helmstatusses = append(helmstatusses, helmstatus)
+
+					log(3, "release: \"%s\" upgraded", dependency.UsedName)
+					if p.verbose {
+						log(3, "helm status: %s", helmstatus.Status)
+					}
+
+					if p.verbose {
+						log(3, "helm resources:")
+						var scanner = bufio.NewScanner(strings.NewReader(helmstatus.Resources))
+						for scanner.Scan() {
+							if len (scanner.Text()) > 0 {
+								log(4, scanner.Text())
+							}
 						}
 					}
 
-					fmt.Println("[spray] release: \"" + dependency.UsedName + "\" upgraded")
+					if helmstatus.Status == "" {
+						log(2, "Warning: no status returned by helm.")
+					} else if helmstatus.Status != "DEPLOYED" {
+						log(2, "Error: status returned by helm differs from \"DEPLOYED\". Cannot continue spray processing.")
+						os.Exit(1)
+					}
 				}
 			}
 		}
 
 		// Wait availability of the Deployment just upgraded
 		if shouldWait {
-			fmt.Println("[spray] waiting for Liveness and Readiness...")
+			log(2, "waiting for Liveness and Readiness...")
 
 			if !p.dryRun {
-				for _, dependency := range dependencies {
-					if dependency.Weight == i && dependency.Targeted == true {
+				for _, status := range helmstatusses {
+					// Wait for completion of the Deployments update
+					for _, dep := range status.Deployments {
 						for {
-							if kubectl.IsDeploymentUpToDate(dependency.UsedName, p.namespace) {
+							if p.verbose {
+								log(3, "waiting for Deployment \"%s\"", dep)
+							}
+							if kubectl.IsDeploymentUpToDate(dep, p.namespace) {
+								break
+							}
+							time.Sleep(5 * time.Second)
+						}
+					}
+
+					// Wait for completion of the StatefulSets update
+					for _, ss := range status.StatefulSets {
+						for {
+							if p.verbose {
+								log(3, "waiting for StatefulSet \"%s\"", ss)
+							}
+							if kubectl.IsStatefulSetUpToDate(ss, p.namespace) {
+								break
+							}
+							time.Sleep(5 * time.Second)
+						}
+					}
+
+					// Wait for completion of the Jobs
+					for _, job := range status.Jobs {
+						for {
+							if p.verbose {
+								log(3, "waiting for Job \"%s\"", job)
+							}
+							if kubectl.IsJobCompleted(job, p.namespace) {
 								break
 							}
 							time.Sleep(5 * time.Second)
@@ -271,7 +348,7 @@ func (p *sprayCmd) spray() error {
 		}
 	}
 
-	fmt.Println("[spray] upgrade completed.")
+	log(1, "upgrade of solution chart \"%s\" completed", p.chartName)
 
 	return nil
 }
@@ -287,6 +364,23 @@ func getMaxWeight(v []Dependency) (m int) {
 		}
 	}
 	return m
+}
+
+// Log spray messages
+func log(level int, str string, params ...interface{}) {
+	var logStr = "[spray] "
+
+	if level == 2 {
+		logStr = logStr + "  > "
+	} else if level == 3 {
+		logStr = logStr + "    o "
+	} else if level == 4 {
+		logStr = logStr + "      - "
+	} else if level >= 5 {
+		logStr = logStr + "        . "
+	}
+
+	fmt.Println(logStr + fmt.Sprintf(str, params...))
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"text/tabwriter"
 
 	"github.com/gemalto/helm-spray/pkg/helm"
 	"github.com/gemalto/helm-spray/pkg/kubectl"
@@ -245,6 +246,10 @@ func (p *sprayCmd) spray() error {
 	helmReleases := helm.List(p.namespace)
 
 	if p.verbose {
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.Debug)
+		fmt.Fprintln(w, "[spray]  \tsubchart\tis alias of\ttargeted\tweight\t|corresponding release\trevision\tstatus\t")
+		fmt.Fprintln(w, "[spray]  \t--------\t-----------\t--------\t------\t|---------------------\t--------\t------\t")
+
 		for _, dependency := range dependencies {
 			currentRevision := "None"
 			currentStatus := "Not deployed"
@@ -254,14 +259,13 @@ func (p *sprayCmd) spray() error {
 			}
 
 			if dependency.Alias == "" {
-				log(2, "subchart \"%s\" - targeted: %t - weight: %d", dependency.Name, dependency.Targeted, dependency.Weight)
-				log(3, "corresponding release: \"%s\" - current revision: %s - current status: %s", dependency.CorrespondingReleaseName, currentRevision, currentStatus)
+				fmt.Fprintln(w, fmt.Sprintf ("[spray]  \t%s\t%s\t%t\t%d\t|%s\t%s\t%s\t", dependency.Name, "-", dependency.Targeted, dependency.Weight, dependency.CorrespondingReleaseName, currentRevision, currentStatus))
 
 			} else {
-				log(2, "subchart \"%s\" (is alias of \"%s\") - targeted: %t - weight: %d", dependency.Alias, dependency.Name, dependency.Targeted, dependency.Weight)
-				log(3, "corresponding release: \"%s\" - current revision: %s - current status: %s", dependency.CorrespondingReleaseName, currentRevision, currentStatus)
+				fmt.Fprintln(w, fmt.Sprintf ("[spray]  \t%s\t%s\t%t\t%d\t|%s\t%s\t%s\t", dependency.Alias, dependency.Name, dependency.Targeted, dependency.Weight, dependency.CorrespondingReleaseName, currentRevision, currentStatus))
 			}
 		}
+w.Flush()
 	}
 
 	// Loop on the increasing weight

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -237,35 +237,31 @@ func Delete(chart string, dryRun bool) {
 }
 
 // UpgradeWithValues ...
-func UpgradeWithValues(namespace string, release string, chartName string, chartPath string, resetValues bool, reuseValues bool, valueFiles []string, valuesSet string, force bool, dryRun bool, debug bool) HelmStatus {
-	var myargs []string = []string{"upgrade", "--install", release, chartPath, "--namespace", namespace, "--set", valuesSet}
+func UpgradeWithValues(namespace string, releaseName string, chartPath string, resetValues bool, reuseValues bool, valueFiles []string, valuesSet string, force bool, dryRun bool, debug bool) HelmStatus {
+	// Prepare parameters...
+	var myargs []string = []string{"upgrade", "--install", releaseName, chartPath, "--namespace", namespace, "--set", valuesSet}
 	for _, v := range valueFiles {
 		myargs = append(myargs, "-f")
 		myargs = append(myargs, v)
 	}
-
 	if resetValues {
 		myargs = append(myargs, "--reset-values")
 	}
-
 	if reuseValues {
 		myargs = append(myargs, "--reuse-values")
 	}
-
 	if force {
 		myargs = append(myargs, "--force")
 	}
-
 	if dryRun {
 		myargs = append(myargs, "--dry-run")
 	}
-
 	if debug {
 		myargs = append(myargs, "--debug")
-		fmt.Printf("[spray] running helm command for \"%s\": %v\n", release, myargs)
+		fmt.Printf("[spray] running helm command for \"%s\": %v\n", releaseName, myargs)
 	}
 
-
+	// Run the upgrade command
 	cmd := exec.Command("helm", myargs...)
 
 	cmdOutput := &bytes.Buffer{}
@@ -277,13 +273,12 @@ func UpgradeWithValues(namespace string, release string, chartName string, chart
 	if debug {
 		fmt.Printf(string(output))
 	}
-
 	if err != nil {
 		printError(err)
 		os.Exit(1)
 	}
 
-	// but in both cases, stdout is required to get and parse the ending helm status.
+	// Parse the ending helm status.
 	helmstatus := HelmStatus{}
 	parseStatusOutput(output, &helmstatus)
 	return helmstatus


### PR DESCRIPTION
This pull request is addressing issues https://github.com/gemalto/helm-spray/issues/15 and https://github.com/gemalto/helm-spray/issues/9.

It bug-fixes:
- The "wait liveness and readiness" phase for Deployments

It adds:
- The capability to wait for Job completion and Statefulset deployment during the "wait liveness and readiness" phase
- The new `--prefix-releases and `--prefix-releases-with-namespace` options to prefix the name of the releases (especially useful for deploying the same charts in several different namespaces)
- The new `--verbose` option to give more information on the Spray processing, without activating the full power (and very verbose) `--debug` option that is transmitted to helm