### PR TITLE
New --timeout parameter + bugfix chart fetching

### DIFF
--- a/main.go
+++ b/main.go
@@ -405,6 +405,7 @@ w.Flush()
 						if !done {
 							os.Stderr.WriteString("Error: UPGRADE FAILED: timed out waiting for the condition\n")
 							os.Stderr.WriteString("==> Error: exit status 1\n")
+							os.Exit(1)
 						}
 					}
 
@@ -427,6 +428,7 @@ w.Flush()
 						if !done {
 							os.Stderr.WriteString("Error: UPGRADE FAILED: timed out waiting for the condition\n")
 							os.Stderr.WriteString("==> Error: exit status 1\n")
+							os.Exit(1)
 						}
 					}
 				}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -15,6 +15,7 @@ package helm
 import (
 	"bytes"
 	"strings"
+    "strconv"
 	"bufio"
 	"fmt"
 	"os"
@@ -237,9 +238,9 @@ func Delete(chart string, dryRun bool) {
 }
 
 // UpgradeWithValues ...
-func UpgradeWithValues(namespace string, releaseName string, chartPath string, resetValues bool, reuseValues bool, valueFiles []string, valuesSet string, force bool, dryRun bool, debug bool) HelmStatus {
+func UpgradeWithValues(namespace string, releaseName string, chartPath string, resetValues bool, reuseValues bool, valueFiles []string, valuesSet string, force bool, timeout int, dryRun bool, debug bool) HelmStatus {
 	// Prepare parameters...
-	var myargs []string = []string{"upgrade", "--install", releaseName, chartPath, "--namespace", namespace, "--set", valuesSet}
+	var myargs []string = []string{"upgrade", "--install", releaseName, chartPath, "--namespace", namespace, "--set", valuesSet, "--timeout", strconv.Itoa(timeout)}
 	for _, v := range valueFiles {
 		myargs = append(myargs, "-f")
 		myargs = append(myargs, v)

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"strconv"
 	"bufio"
+	"io/ioutil"
 	"fmt"
 	"os"
 	"os/exec"
@@ -304,12 +305,19 @@ func Status(chart string) HelmStatus {
 
 // Fetch ...
 func Fetch(chart string, version string) string {
+	tempDir, err := ioutil.TempDir("", "spray-")
+	if err != nil {
+		printError(err)
+	}
+	defer os.RemoveAll(tempDir)
+
 	var command string
 	if version != "" {
-		command = "mkdir /tmp/$$ && helm fetch " + chart + " --destination /tmp/$$ --version " + version + " && ls /tmp/$$ && mv /tmp/$$/* . && rmdir /tmp/$$"
+		command = "helm fetch " + chart + " --destination " + tempDir + " --version " + version
 	} else {
-		command = "mkdir /tmp/$$ && helm fetch " + chart + " --destination /tmp/$$  && ls /tmp/$$ && mv /tmp/$$/* . && rmdir /tmp/$$"
+		command = "helm fetch " + chart + " --destination " + tempDir
 	}
+	command = command + " && ls " + tempDir + " && cp " + tempDir + "/* ."
 
 	cmd := exec.Command("sh", "-c", command)
 	cmdOutput := &bytes.Buffer{}


### PR DESCRIPTION
This PR addresses both issues https://github.com/gemalto/helm-spray/issues/17 and https://github.com/gemalto/helm-spray/issues/18.
- It adds a new `--timeout` parameter to specify a timeout value (in seconds) for both the Helm commands calls and the "wait Liveness and Readiness" phase. This parameter has a default value of 300s.
- It corretly manages the chart fetching in the use cases mentioned in https://github.com/gemalto/helm-spray/issues/18.