### PR TITLE
Support of Helm Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ micro-service-2 21              Wed Jan 30 17:18:55 2019        DEPLOYED        
 ms3             7               Wed Jan 30 17:18:45 2019        DEPLOYED        solution-0.1    0.1             default
 ```
 
-Note: if an alias is set for a sub-chart, then this is this alias that should be used with the `--target` optioni, not the sub-chart name.
+Note: if an alias is set for a sub-chart, then this is this alias that should be used with the `--target` option, not the sub-chart name.
 
 ### Values:
 
@@ -109,6 +109,38 @@ ms3:
       dummy: "just here to prevent from a warning"
 
 ```
+
+### Tags and Conditions:
+
+As Helm Spray internally uses the Helm Conditions for its own purpose, it is not possible to specify other Conditions that the ones required by Helm Spray itself (`<chart name or alias>.enabled`). Such extra Conditions will be ignored.
+
+However, Helm Spray is compatible with Tags set in the `requirements.yaml` file, as displayed in the following example:
+```
+dependencies:
+- name: micro-service-1
+  version: ~1.2
+  repository: http://chart-museum/charts
+  condition: micro-service-1.enabled
+  tags:
+  - common
+  - front-end
+- name: micro-service-2
+  version: ~2.3
+  repository: http://chart-museum/charts
+  condition: micro-service-2.enabled
+  tags:
+  - common
+  - back-end
+- name: micro-service-3
+  alias: ms3
+  version: ~1.1
+  repository: http://chart-museum/charts
+  condition: ms3.enabled
+```
+With such a configuration, if Helm Spray is called with the `--set tags.front-end=true` argument, the `micro-service-1` will be deployed (because it has a tag that matches one of those given in the command line) and `micro-service-3` as well (because it has no tag, so no restriction applies), while `micro-service-2` will not be deployed (because it has tags and none of them is matching one of those given in the command line).
+
+Note that tags shall be provided through the `--values`/`-f`, `--set`, `--set-string`, or `--set-file` flags: values coming from the server/Tiller (for example when using the `--reuse-values` flag) are not considered.
+Tags values can also not be templated (e.g. `tags.front-end` set to `{{ .Values.x.y.z }}` will not be processed).
 
 ### Flags:
 
@@ -168,10 +200,4 @@ $ SKIP_BIN_INSTALL=1 helm plugin install $GOPATH/src/github.com/gemalto/helm-spr
 
 That last command will skip fetching the binary install and use the one you
 built.
-
-
-
-
-
-
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ ms3:
 ```
 Several sub-charts may have the same weight, meaning that they will be upgraded together.
 Upgrade of sub-charts of weight n+1 will only be triggered when upgrade of sub-charts of weight n is completed.
+Note also that while weights should primarilly be set in the `values.yaml` file of the umbrella chart, it is also possible to set them using the `--values/-f` or `--set` flags of the command line, for example to temporarilly overwrite a weight value. If so, take care that weight values provided through the command line are not taken into account for the next calls to Helm Spray, including if the `--reuse-values` flag is used: they would have to be provided again at each call.
+
 
 Helm Spray creates one helm Release per sub-chart. Releases are individually upgraded when running the helm spray process, in particular when using the `--target` option.
 The name and version of the umbrella chart is set as the Chart name for all the Revisions.
@@ -78,7 +80,7 @@ Note: if an alias is set for a sub-chart, then this is this alias that should be
 The umbrella chart gathers several components or micro-services into a single solution. Values can then be set at many different places:
 - At micro-service level, inside the `values.yaml` file of each micro-service chart: these are common defaults values set by the micro-service developer, independently from the deployment context and location of the micro-service
 - At the solution level, inside the `values.yaml` file of the umbrella chart: these are values complementing or overwriting default values of the micro-services sub-charts, usually formalizing the deployment topology of the solution and giving the standard configuration of the underlying micro-services for any deployments of cwthis specific solution
-- At deployment time, using the `--values/-f` or `--set` flags: this is the placeholder for giving the deployment-dependent values, specifying for example the exact database url for this deployment, the exact password value for this deployment, the targeted remote server url for this deployment, etc. These values usually change from one deployment of the solution to another.
+- At deployment time, using the `--values/-f`, `--set`, `--set-string`, or `--set-file` flags: this is the placeholder for giving the deployment-dependent values, specifying for example the exact database url for this deployment, the exact password value for this deployment, the targeted remote server url for this deployment, etc. These values usually change from one deployment of the solution to another.
 
 Within the micro-services paradigm, decoupling between micro-services is one of the most important criteria to respect. While values con be provided in a per-micro-service basis for the first and last places mentioned above, Helm only allows one single `values.yaml` file in the umbrella chart. All solution-level values should then be gathered into a single file, while it would have been better to provide values in several files, on a one-file-per-micro-service basis (to ensure decoupling of the micro-services configuration, even at solution level).
 Helm Spray is consequently adding this capability to have several values file in the umbrella chart and to include them into the single `values.yaml` file using the `#! {{ .File.Get <file name> }}` directive.

--- a/main.go
+++ b/main.go
@@ -279,9 +279,12 @@ func (p *sprayCmd) spray() error {
 	if err := yaml.Unmarshal([]byte (localValues), &localValuesAsMap); err != nil {
 		logErrorAndExit("Error parsing values to get 'tags' content")
 	}
-	providedTags := localValuesAsMap["tags"].(map[string]interface{})
+	var providedTags map[string]interface{}
+    if localValuesAsMap["tags"] != nil {
+        providedTags = localValuesAsMap["tags"].(map[string]interface{})
+    }
 
-	if p.verbose && (len (providedTags) > 0) {
+	if p.verbose {
 		log(1, "looking for \"tags\" in values provided through \"--values/-f\", \"--set\", \"--set-string\", and \"--set-file\"...")
 		for k, v := range providedTags {
 			log(2, fmt.Sprintf("found tag \"%s: %s\"", k, fmt.Sprint(v)))

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -301,10 +301,15 @@ func UpgradeWithValues(namespace string, releaseName string, chartPath string, r
 	return helmstatus
 }
 
-// GetLocalValues ...
-func GetLocalValues(chartPath string, valueFiles []string, valuesSet []string, valuesSetString []string, valuesSetFile []string) string {
+// Template ...
+func Template(chartPath string, fileToExecute string, valueFiles []string, valuesSet []string, valuesSetString []string, valuesSetFile []string) string {
 	// Prepare parameters...
 	var myargs []string = []string{"template", chartPath, "--debug"}
+
+	if fileToExecute != "" {
+		myargs = append(myargs, "--execute")
+		myargs = append(myargs, fileToExecute)
+	}
 
 	for _, v := range valuesSet {
 		myargs = append(myargs, "--set")
@@ -337,9 +342,7 @@ func GetLocalValues(chartPath string, valueFiles []string, valuesSet []string, v
 		os.Exit(1)
 	}
 
-	values := getStringBetween(string(output), "COMPUTED VALUES:", "HOOKS:")
-
-	return values
+	return string(output)
 }
 
 // Status ...

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -301,6 +301,47 @@ func UpgradeWithValues(namespace string, releaseName string, chartPath string, r
 	return helmstatus
 }
 
+// GetLocalValues ...
+func GetLocalValues(chartPath string, valueFiles []string, valuesSet []string, valuesSetString []string, valuesSetFile []string) string {
+	// Prepare parameters...
+	var myargs []string = []string{"template", chartPath, "--debug"}
+
+	for _, v := range valuesSet {
+		myargs = append(myargs, "--set")
+		myargs = append(myargs, v)
+	}
+	for _, v := range valuesSetString {
+		myargs = append(myargs, "--set-string")
+		myargs = append(myargs, v)
+	}
+	for _, v := range valuesSetFile {
+		myargs = append(myargs, "--set-file")
+		myargs = append(myargs, v)
+	}
+	for _, v := range valueFiles {
+		myargs = append(myargs, "-f")
+		myargs = append(myargs, v)
+	}
+
+	// Run the template command
+	cmd := exec.Command("helm", myargs...)
+
+	cmdOutput := &bytes.Buffer{}
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = cmdOutput
+	err := cmd.Run()
+	output := cmdOutput.Bytes()
+
+	if err != nil {
+		printError(err)
+		os.Exit(1)
+	}
+
+	values := getStringBetween(string(output), "COMPUTED VALUES:", "HOOKS:")
+
+	return values
+}
+
 // Status ...
 func Status(chart string) HelmStatus {
 	cmd := exec.Command("helm", "status", chart)


### PR DESCRIPTION
This PR is addressing issue https://github.com/gemalto/helm-spray/issues/32.

Helm Spray is now compatible with Tags set in the `requirements.yaml` file.

However, tags shall be provided through the `--values`/`-f`, `--set`, `--set-string`, or `--set-file` flags: values coming from the server/Tiller (for example when using the `--reuse-values` flag) are not considered.
Tags values can also not be templated (e.g. `tags.front-end` set to `{{ .Values.x.y.z }}` will not be processed).
