### PR TITLE
fix(#93): strip spray-owned `weight` keys before Helm schema validation

### DIFF
--- a/internal/values/values.go
+++ b/internal/values/values.go
@@ -183,6 +183,53 @@ func processIncludeInValuesFile(chart *chart.Chart, verbose bool) (string, error
 	return chartValues, nil
 }
 
+// SprayValuesKeys lists the keys that helm-spray reads from values.yaml as
+// out-of-band metadata for its own use (currently: deployment ordering). These
+// keys are not part of any chart's templating contract and must be stripped
+// from the values document handed to "helm upgrade" so that umbrella charts
+// shipping a strict values.schema.json (additionalProperties: false) do not
+// fail validation.
+var SprayValuesKeys = []string{"weight"}
+
+// StripSprayKeys removes helm-spray-owned keys from a YAML values document for
+// each dependency declared by the umbrella chart. The in-memory values map
+// used by helm-spray for ordering decisions is unaffected; only the textual
+// representation handed to "helm upgrade -f" is.
+func StripSprayKeys(yamlStr string, chrt *chart.Chart) (string, error) {
+	if yamlStr == "" || chrt == nil || len(chrt.Metadata.Dependencies) == 0 {
+		return yamlStr, nil
+	}
+	parsed, err := chartutil.ReadValues([]byte(yamlStr))
+	if err != nil {
+		return "", fmt.Errorf("parsing values for spray-key stripping: %w", err)
+	}
+	changed := false
+	for _, req := range chrt.Metadata.Dependencies {
+		usedName := req.Alias
+		if usedName == "" {
+			usedName = req.Name
+		}
+		sub, err := parsed.Table(usedName)
+		if err != nil {
+			continue
+		}
+		for _, key := range SprayValuesKeys {
+			if _, ok := sub[key]; ok {
+				delete(sub, key)
+				changed = true
+			}
+		}
+	}
+	if !changed {
+		return yamlStr, nil
+	}
+	cleaned, err := parsed.YAML()
+	if err != nil {
+		return "", fmt.Errorf("re-serialising values after spray-key stripping: %w", err)
+	}
+	return cleaned, nil
+}
+
 func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
 	out := make(map[string]interface{}, len(a))
 	for k, v := range a {

--- a/pkg/helmspray/helmspray.go
+++ b/pkg/helmspray/helmspray.go
@@ -9,13 +9,16 @@ import (
 	"github.com/gemalto/helm-spray/v4/pkg/helm"
 	"github.com/gemalto/helm-spray/v4/pkg/kubectl"
 	"github.com/gemalto/helm-spray/v4/pkg/util"
+	helmChart "helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
 	cliValues "helm.sh/helm/v3/pkg/cli/values"
 	"io/ioutil"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -64,6 +67,14 @@ func (s *Spray) Spray() error {
 		return fmt.Errorf("merging values: %w", err)
 	}
 	if len(updatedChartValuesAsString) > 0 {
+		// Strip helm-spray-owned keys (e.g. "weight") so the temp values file
+		// passed to "helm upgrade -f" does not trip values.schema.json
+		// validation when the umbrella chart ships a strict schema. The
+		// in-memory mergedValues used below for ordering decisions is intact.
+		updatedChartValuesAsString, err = values.StripSprayKeys(updatedChartValuesAsString, chart)
+		if err != nil {
+			return fmt.Errorf("stripping spray-owned keys from values: %w", err)
+		}
 		// Write default values to a temporary file and add it to the list of values files,
 		// for later usage during the calls to helm
 		tempDir, err := ioutil.TempDir("", "spray-")
@@ -98,6 +109,20 @@ func (s *Spray) Spray() error {
 		return fmt.Errorf("analyzing dependencies: %w", err)
 	}
 
+	// Materialise a sanitised copy of the chart in a temp directory. Helm
+	// validates the COALESCED values document (chart defaults + overlays + set
+	// flags) against values.schema.json, so leaving "weight" in the chart's
+	// on-disk values.yaml — even when overlays have been stripped — still
+	// trips schema validation. Writing a stripped copy of the chart and
+	// pointing "helm upgrade" at that copy closes the validation hole.
+	// "deps" above has already captured the weights, so it is safe to mutate
+	// the chart's in-memory values now.
+	strippedChartPath, cleanupChart, err := materialiseStrippedChart(chart)
+	if err != nil {
+		return fmt.Errorf("materialising stripped chart: %w", err)
+	}
+	defer cleanupChart()
+
 	// Starting the processing...
 	if len(releasePrefix) > 0 {
 		log.Info(1, "deploying solution chart \"%s\" in namespace \"%s\", with releases releasePrefix \"%s-\"", s.ChartName, s.Namespace, releasePrefix)
@@ -121,7 +146,7 @@ func (s *Spray) Spray() error {
 
 	// Loop on the increasing weight
 	for i := 0; i <= maxWeight(deps); i++ {
-		shouldWait, err := s.upgrade(releases, deps, i)
+		shouldWait, err := s.upgrade(releases, deps, i, strippedChartPath)
 		if err != nil {
 			return err
 		}
@@ -139,7 +164,7 @@ func (s *Spray) Spray() error {
 	return nil
 }
 
-func (s *Spray) upgrade(releases map[string]helm.Release, deps []dependencies.Dependency, currentWeight int) (bool, error) {
+func (s *Spray) upgrade(releases map[string]helm.Release, deps []dependencies.Dependency, currentWeight int, chartPath string) (bool, error) {
 	shouldWait := false
 	firstInWeight := true
 	// Upgrade the targeted Deployments corresponding the the current weight
@@ -182,7 +207,7 @@ func (s *Spray) upgrade(releases map[string]helm.Release, deps []dependencies.De
 					s.Namespace,
 					s.CreateNamespace,
 					dependency.CorrespondingReleaseName,
-					s.ChartName,
+					chartPath,
 					s.ResetValues,
 					s.ReuseValues,
 					s.ValuesOpts.ValueFiles,
@@ -385,6 +410,98 @@ func logRelease(releases map[string]helm.Release, deps []dependencies.Dependency
 		_, _ = fmt.Fprintln(w, fmt.Sprintf("[spray]  \t %s\t %s\t %s\t %d\t| %s\t %s\t %s\t", name, alias, targeted, dependency.Weight, dependency.CorrespondingReleaseName, currentRevision, currentStatus))
 	}
 	_ = w.Flush()
+}
+
+// materialiseStrippedChart writes a sanitised copy of the loaded chart to a
+// fresh temp directory, with helm-spray-owned keys (currently "weight")
+// removed from the umbrella's values.yaml and from each direct subchart's
+// values.yaml. The returned path is suitable for passing to "helm upgrade".
+//
+// Why this exists: Helm validates the COALESCED values document against
+// values.schema.json, which means the chart's on-disk values are part of the
+// validation surface. Stripping only the overlay file we hand to "helm -f" is
+// not enough — the schema still trips on "weight" coming from the chart's own
+// values.yaml. Pointing helm at a sanitised chart copy is the only way to
+// keep umbrella charts with strict schemas working.
+//
+// chartutil.SaveDir writes values.yaml from chrt.Raw (the raw file bytes),
+// not from chrt.Values, so we mutate Raw rather than the parsed map.
+// Callers must have already extracted any spray-owned data they need
+// (deployment order) before invoking this.
+func materialiseStrippedChart(chrt *helmChart.Chart) (string, func(), error) {
+	noop := func() {}
+
+	// Rewrite the umbrella's values.yaml bytes in Raw, stripping <dep>.weight
+	// for each declared dependency.
+	if err := stripWeightFromRawValues(chrt, true); err != nil {
+		return "", noop, fmt.Errorf("stripping umbrella values: %w", err)
+	}
+	// Rewrite each direct subchart's values.yaml bytes in Raw, stripping
+	// a top-level "weight" key (which becomes <dep>.weight after coalesce).
+	for _, sub := range chrt.Dependencies() {
+		if err := stripWeightFromRawValues(sub, false); err != nil {
+			return "", noop, fmt.Errorf("stripping subchart %q values: %w", sub.Name(), err)
+		}
+	}
+
+	tmpParent, err := os.MkdirTemp("", "spray-chart-")
+	if err != nil {
+		return "", noop, fmt.Errorf("creating temp chart dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpParent) }
+
+	if err := chartutil.SaveDir(chrt, tmpParent); err != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("writing stripped chart to temp dir: %w", err)
+	}
+
+	return filepath.Join(tmpParent, chrt.Name()), cleanup, nil
+}
+
+// stripWeightFromRawValues finds values.yaml in chrt.Raw and rewrites it with
+// the "weight" key removed. For the umbrella (umbrella=true) it strips
+// <usedName>.weight for each declared dependency; for a subchart it strips
+// the top-level "weight" key.
+func stripWeightFromRawValues(chrt *helmChart.Chart, umbrella bool) error {
+	for i, f := range chrt.Raw {
+		if f.Name != chartutil.ValuesfileName {
+			continue
+		}
+		parsed, err := chartutil.ReadValues(f.Data)
+		if err != nil {
+			return fmt.Errorf("parsing values.yaml: %w", err)
+		}
+		changed := false
+		if umbrella {
+			for _, dep := range chrt.Metadata.Dependencies {
+				usedName := dep.Alias
+				if usedName == "" {
+					usedName = dep.Name
+				}
+				if sub, ok := parsed[usedName].(map[string]interface{}); ok {
+					if _, has := sub["weight"]; has {
+						delete(sub, "weight")
+						changed = true
+					}
+				}
+			}
+		} else {
+			if _, has := parsed["weight"]; has {
+				delete(parsed, "weight")
+				changed = true
+			}
+		}
+		if !changed {
+			return nil
+		}
+		cleaned, err := parsed.YAML()
+		if err != nil {
+			return fmt.Errorf("re-serialising values.yaml: %w", err)
+		}
+		chrt.Raw[i].Data = []byte(cleaned)
+		return nil
+	}
+	return nil
 }
 
 func removeTempDir(tempDir string) {


### PR DESCRIPTION
Helm 3 charts with `values.schema.json` and `additionalProperties: false` reject `weight`, blocking helm-spray's wave ordering on schema-validated umbrella charts. Validation runs against the coalesced values document, so closing only one vector is silently incomplete.

Two-layer fix:

- internal/values/values.go: new `StripSprayKeys` helper removes `<dep>.weight` from the YAML overlay text passed via `helm upgrade -f`. Idempotent; the in-memory ordering map is unaffected.

- pkg/helmspray/helmspray.go: `materialiseStrippedChart` writes a sanitised copy of the chart to a temp directory by mutating `chrt.Raw[].Data` (not `chrt.Values` — `chartutil.SaveDir` reads from Raw). Strips `<dep>.weight` from the umbrella's values.yaml and top-level `weight` from each subchart's values.yaml. Spray then invokes `helm.UpgradeWithValues` against the stripped chart path.

Stripping happens after `dependencies.Get`, so wave ordering is preserved. Verified end-to-end against a synthetic reproducer and the OTA Cloud production umbrella (apiVersion v1, requirements.yaml-driven, .tgz subcharts).