### PR TITLE
Prepare portable release builds and Helm 4 compatibility tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 .idea/
+bin/
+_dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 4.0.14 - 06/25/2026
+* Added portable release builds for Linux arm64, Darwin arm64, and static Linux compatibility
+* Added Helm 4 smoke and integration test scripts
+* Updated dry-run handling for Helm 4 compatibility
+* Updated plugin installer architecture selection
+
 ## Version 4.0.13 - 11/27/2024
 * Bump to helm v3.16.3, k8s.io/api v0.31.3, go 1.22, and k8s.io/client-go v0.31.3
 * Fixed [`#92`](https://github.com/ThalesGroup/helm-spray/issues/92) (barmaths)

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,41 @@
 VERSION := $(shell sed -n -e 's/version:[ "]*\([^"]*\).*/\1/p' plugin.yaml)
 DIST := $(CURDIR)/_dist
-LDFLAGS := "-X main.version=${VERSION}"
-TAR_LINUX := "helm-spray-linux-amd64.tar.gz"
-TAR_WINDOWS := "helm-spray-windows-amd64.tar.gz"
-TAR_DARWIN := "helm-spray-darwin-amd64.tar.gz"
-BINARY_LINUX := "helm-spray"
-BINARY_WINDOWS := "helm-spray.exe"
-BINARY_DARWIN := "helm-spray"
+LDFLAGS := -s -w -X github.com/gemalto/helm-spray/v4/cmd.version=$(VERSION)
+DIST_TARGETS := dist_linux_amd64 dist_linux_arm64 dist_darwin_amd64 dist_darwin_arm64 dist_windows_amd64
 
-.PHONY: dist
+BINARY_linux := helm-spray
+BINARY_darwin := helm-spray
+BINARY_windows := helm-spray.exe
 
-dist: dist_darwin dist_linux dist_windows
+.PHONY: build clean dist helm4-integration helm4-smoke test $(DIST_TARGETS)
 
-dist_darwin:
-	mkdir -p $(DIST)
-	GOOS=darwin GOARCH=amd64 go get -t -v ./...
-	GOOS=darwin GOARCH=amd64 go build -o bin/$(BINARY_DARWIN) -ldflags $(LDFLAGS) main.go
-	tar -czvf $(DIST)/$(TAR_DARWIN) bin README.md LICENSE plugin.yaml
+build:
+	CGO_ENABLED=0 go build -trimpath -o bin/helm-spray -ldflags "$(LDFLAGS)" main.go
 
-dist_linux:
-	mkdir -p $(DIST)
-	GOOS=linux GOARCH=amd64 go get -t -v ./...
-	GOOS=linux GOARCH=amd64 go build -o bin/$(BINARY_LINUX) -ldflags $(LDFLAGS) main.go
-	tar -czvf $(DIST)/$(TAR_LINUX) bin README.md LICENSE plugin.yaml
+test:
+	go test ./...
 
-.PHONY: dist_windows
-dist_windows:
-	mkdir -p $(DIST)
-	GOOS=windows GOARCH=amd64 go get -t -v ./...
-	GOOS=windows GOARCH=amd64 go build -o bin/$(BINARY_WINDOWS) -ldflags $(LDFLAGS) main.go
-	tar -czvf $(DIST)/${TAR_WINDOWS} bin README.md LICENSE plugin.yaml
+dist: clean test $(DIST_TARGETS)
+
+helm4-smoke:
+	scripts/helm4_smoke_test.sh
+
+helm4-integration:
+	scripts/helm4_integration_tests.sh
+
+clean:
+	rm -rf bin $(DIST)
+
+define build_archive
+dist_$(1)_$(2):
+	mkdir -p $(DIST)/$(1)-$(2)/bin
+	CGO_ENABLED=0 GOOS=$(1) GOARCH=$(2) go build -trimpath -o $(DIST)/$(1)-$(2)/bin/$$(BINARY_$(1)) -ldflags "$(LDFLAGS)" main.go
+	cp README.md LICENSE plugin.yaml $(DIST)/$(1)-$(2)/
+	tar -C $(DIST)/$(1)-$(2) -czvf $(DIST)/helm-spray-$(1)-$(2).tar.gz bin README.md LICENSE plugin.yaml
+endef
+
+$(eval $(call build_archive,linux,amd64))
+$(eval $(call build_archive,linux,arm64))
+$(eval $(call build_archive,darwin,amd64))
+$(eval $(call build_archive,darwin,arm64))
+$(eval $(call build_archive,windows,amd64))

--- a/TASKS-5-6.md
+++ b/TASKS-5-6.md
@@ -1,0 +1,106 @@
+# Tasks 5-6: Release Portability and Helm 4 Compatibility
+
+This file tracks the work owned for items 5 and 6:
+
+- Modernize release builds for Linux compatibility.
+- Validate Helm 4 compatibility.
+
+## Task 5: Portable Release Builds
+
+### Goal
+
+Produce release artifacts that run across common Linux distributions without depending on the build host's glibc version, and add Apple Silicon support.
+
+### Current Problems
+
+- Linux release binaries are built without `CGO_ENABLED=0`, so they can inherit glibc requirements from the build environment.
+- The Makefile only produces `amd64` artifacts.
+- Release targets run `go get -t -v ./...`, which can mutate module state during builds.
+- Build artifacts are written into `bin/`, but the directory is not ignored by git.
+
+### Implementation Checklist
+
+- Add a reusable Makefile build target for platform-specific archives.
+- Build releases with `CGO_ENABLED=0`.
+- Support these archives:
+  - `helm-spray-linux-amd64.tar.gz`
+  - `helm-spray-linux-arm64.tar.gz`
+  - `helm-spray-darwin-amd64.tar.gz`
+  - `helm-spray-darwin-arm64.tar.gz`
+  - `helm-spray-windows-amd64.tar.gz`
+- Replace `go get -t -v ./...` with build-safe commands.
+- Add `bin/` and `_dist/` to `.gitignore`.
+- Verify Linux artifacts in a minimal container.
+
+### Suggested Verification
+
+```sh
+make clean
+make test
+make dist
+docker run --rm -v "$PWD/_dist:/dist" alpine:3.20 sh -c \
+  'tar -xzf /dist/helm-spray-linux-amd64.tar.gz -C /tmp && /tmp/bin/helm-spray --help'
+```
+
+## Task 6: Helm 4 Compatibility Testing
+
+### Goal
+
+Provide repeatable checks proving the existing legacy CLI plugin path works with Helm 4, then document any behavior differences.
+
+### Current Helm 4 Observations
+
+- `helm spray --help` works under Helm `v4.2.2`.
+- `helm plugin list` reports the plugin as `cli/v1 legacy`.
+- A local kind smoke test can deploy a two-subchart umbrella chart with weighted releases.
+
+### Compatibility Checklist
+
+- Verify `helm list -o json` still matches the plugin's release parsing.
+- Verify `helm upgrade --install -o json` still matches the plugin's upgrade parsing.
+- Verify local chart install.
+- Verify `--target`.
+- Verify `--exclude`.
+- Verify `--dry-run --debug`.
+- Verify `--reuse-values`.
+- Check whether Helm 4 emits deprecation warnings for `--force`.
+- Keep the plugin as a legacy CLI plugin for the first Helm 4 compatibility pass.
+
+### Suggested Smoke Test
+
+```sh
+make helm4-smoke
+```
+
+The smoke script builds the local plugin into an isolated temporary Helm plugin
+directory, creates or reuses a kind cluster, generates a two-subchart umbrella
+chart, and checks normal, `--target`, `--exclude`, and `--dry-run --debug`
+flows.
+
+### Suggested Integration Test
+
+```sh
+make helm4-integration
+```
+
+The integration script uses a fresh namespace by default and adds assertions for:
+
+- Helm 4 legacy plugin registration.
+- Baseline weighted install.
+- `--target`.
+- `--exclude`.
+- tag filtering.
+- explicit release prefixes.
+- namespace-based release prefixes.
+- values file overrides.
+- `--reuse-values`.
+- `--dry-run --debug` without release mutation.
+- invalid target failure.
+- conflicting `--target` and `--exclude` failure.
+
+### Cleanup
+
+```sh
+kind delete cluster --name spray-test
+colima stop
+```

--- a/internal/dependencies/dependencies.go
+++ b/internal/dependencies/dependencies.go
@@ -130,7 +130,7 @@ func tags(values *chartutil.Values, verbose bool) map[string]interface{} {
 	}
 	if verbose {
 		for k, v := range providedTags {
-			log.Info(2, fmt.Sprintf("found tag \"%s: %s\"", k, fmt.Sprint(v)))
+			log.Info(2, "found tag \"%s: %s\"", k, fmt.Sprint(v))
 		}
 	}
 	return providedTags

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -111,7 +111,7 @@ func UpgradeWithValues(level int, namespace string, createNamespace bool, releas
 		myargs = append(myargs, "--force")
 	}
 	if dryRun {
-		myargs = append(myargs, "--dry-run")
+		myargs = append(myargs, "--dry-run=client")
 	}
 	if createNamespace {
 		myargs = append(myargs, "--create-namespace")

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "spray"
-version: 4.0.13
+version: 4.0.14
 usage: "upgrade sub-charts from an umbrella chart with dependency orders"
 description: "Helm plugin for upgrading sub-charts from umbrella chart with dependency orders"
 command: "$HELM_PLUGIN_DIR/bin/helm-spray"

--- a/scripts/helm4_integration_tests.sh
+++ b/scripts/helm4_integration_tests.sh
@@ -1,0 +1,259 @@
+#!/bin/sh
+set -eu
+
+CLUSTER_NAME="${CLUSTER_NAME:-spray-test}"
+NAMESPACE="${NAMESPACE:-spray-itest-$$}"
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/helm-spray-itest.XXXXXX")"
+HELM_PLUGINS_DIR="${WORK_DIR}/helm-plugins"
+CREATED_NAMESPACE=0
+
+cleanup() {
+    if [ "${KEEP_NAMESPACE:-0}" != "1" ] && [ "${CREATED_NAMESPACE}" = "1" ]; then
+        kubectl delete namespace "${NAMESPACE}" --ignore-not-found >/dev/null 2>&1 || true
+    fi
+    rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+log() {
+    printf '\n==> %s\n' "$1"
+}
+
+assert_contains() {
+    haystack="$1"
+    needle="$2"
+    if ! printf '%s' "${haystack}" | grep -Fq -- "${needle}"; then
+        echo "Expected output to contain: ${needle}" >&2
+        exit 1
+    fi
+}
+
+assert_release_exists() {
+    release="$1"
+    helm --namespace "${NAMESPACE}" status "${release}" >/dev/null
+}
+
+assert_release_missing() {
+    release="$1"
+    if helm --namespace "${NAMESPACE}" status "${release}" >/dev/null 2>&1; then
+        echo "Expected release to be missing: ${release}" >&2
+        exit 1
+    fi
+}
+
+assert_configmap_exists() {
+    name="$1"
+    kubectl --namespace "${NAMESPACE}" get configmap "${name}" >/dev/null
+}
+
+expect_failure() {
+    name="$1"
+    shift
+    log "${name}"
+    set +e
+    output="$("$@" 2>&1)"
+    status=$?
+    set -e
+    if [ "${status}" -eq 0 ]; then
+        echo "Expected command to fail: $*" >&2
+        exit 1
+    fi
+    printf '%s\n' "${output}"
+}
+
+write_chart() {
+    chart_dir="$1"
+    mkdir -p "${chart_dir}/charts/app-a/templates" "${chart_dir}/charts/app-b/templates" "${chart_dir}/charts/app-c/templates"
+
+    cat > "${chart_dir}/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: helm-spray-itest
+version: 0.1.0
+dependencies:
+  - name: app-a
+    version: 0.1.0
+    repository: file://charts/app-a
+    condition: app-a.enabled
+    tags:
+      - core
+  - name: app-b
+    version: 0.1.0
+    repository: file://charts/app-b
+    condition: app-b.enabled
+    tags:
+      - optional
+  - name: app-c
+    version: 0.1.0
+    repository: file://charts/app-c
+    condition: app-c.enabled
+EOF
+
+    cat > "${chart_dir}/values.yaml" <<'EOF'
+tags:
+  core: true
+  optional: true
+app-a:
+  enabled: true
+  weight: 0
+  marker: default-a
+app-b:
+  enabled: true
+  weight: 1
+  marker: default-b
+app-c:
+  enabled: true
+  weight: 2
+  marker: default-c
+EOF
+
+    for app in app-a app-b app-c; do
+        cat > "${chart_dir}/charts/${app}/Chart.yaml" <<EOF
+apiVersion: v2
+name: ${app}
+version: 0.1.0
+appVersion: "1.0"
+EOF
+
+        cat > "${chart_dir}/charts/${app}/values.yaml" <<'EOF'
+enabled: true
+weight: 0
+marker: subchart-default
+EOF
+
+        cat > "${chart_dir}/charts/${app}/templates/configmap.yaml" <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-smoke
+data:
+  app: ${app}
+  marker: {{ .Values.marker | quote }}
+EOF
+    done
+}
+
+require go
+require helm
+require kind
+require kubectl
+
+mkdir -p "${HELM_PLUGINS_DIR}/spray/bin"
+cd "${ROOT_DIR}"
+go build -o "${HELM_PLUGINS_DIR}/spray/bin/helm-spray" main.go
+cp plugin.yaml README.md LICENSE "${HELM_PLUGINS_DIR}/spray/"
+export HELM_PLUGINS="${HELM_PLUGINS_DIR}"
+
+if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
+    kind create cluster --name "${CLUSTER_NAME}"
+fi
+
+kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+if ! kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1; then
+    kubectl create namespace "${NAMESPACE}" >/dev/null
+    CREATED_NAMESPACE=1
+fi
+
+CHART_DIR="${WORK_DIR}/chart"
+write_chart "${CHART_DIR}"
+helm dependency build "${CHART_DIR}" >/dev/null
+
+log "Plugin is registered as a Helm 4 legacy CLI plugin"
+plugin_list="$(helm plugin list)"
+printf '%s\n' "${plugin_list}"
+assert_contains "${plugin_list}" "spray"
+assert_contains "${plugin_list}" "legacy"
+
+log "Case 1: baseline weighted install deploys all releases"
+helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --verbose --timeout 60
+assert_release_exists app-a
+assert_release_exists app-b
+assert_release_exists app-c
+assert_configmap_exists app-a-smoke
+assert_configmap_exists app-b-smoke
+assert_configmap_exists app-c-smoke
+
+log "Case 2: --target only upgrades the selected release"
+before_a="$(helm --namespace "${NAMESPACE}" status app-a -o json)"
+before_b="$(helm --namespace "${NAMESPACE}" status app-b -o json)"
+helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --target app-a --verbose --timeout 60
+after_a="$(helm --namespace "${NAMESPACE}" status app-a -o json)"
+after_b="$(helm --namespace "${NAMESPACE}" status app-b -o json)"
+if [ "${before_a}" = "${after_a}" ]; then
+    echo "Expected app-a status to change after --target app-a" >&2
+    exit 1
+fi
+if [ "${before_b}" != "${after_b}" ]; then
+    echo "Expected app-b status to remain unchanged after --target app-a" >&2
+    exit 1
+fi
+
+log "Case 3: --exclude skips the excluded release"
+before_b="$(helm --namespace "${NAMESPACE}" status app-b -o json)"
+helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --exclude app-b --verbose --timeout 60
+after_b="$(helm --namespace "${NAMESPACE}" status app-b -o json)"
+if [ "${before_b}" != "${after_b}" ]; then
+    echo "Expected app-b status to remain unchanged after --exclude app-b" >&2
+    exit 1
+fi
+
+log "Case 4: tag filtering can skip tagged dependencies"
+helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --prefix-releases tagskip --set tags.optional=false --verbose --timeout 60
+assert_release_exists tagskip-app-a
+assert_release_missing tagskip-app-b
+assert_release_exists tagskip-app-c
+
+log "Case 5: explicit release prefix creates independent release names"
+helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --prefix-releases pref --verbose --timeout 60
+assert_release_exists pref-app-a
+assert_release_exists pref-app-b
+assert_release_exists pref-app-c
+assert_configmap_exists pref-app-a-smoke
+
+log "Case 6: namespace prefix creates independent release names"
+helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --prefix-releases-with-namespace --target app-c --verbose --timeout 60
+assert_release_exists "${NAMESPACE}-app-c"
+assert_configmap_exists "${NAMESPACE}-app-c-smoke"
+
+log "Case 7: values file overrides are passed through"
+cat > "${WORK_DIR}/override-values.yaml" <<'EOF'
+app-a:
+  marker: from-values-file
+EOF
+helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --prefix-releases vals -f "${WORK_DIR}/override-values.yaml" --target app-a --verbose --timeout 60
+marker="$(kubectl --namespace "${NAMESPACE}" get configmap vals-app-a-smoke -o jsonpath='{.data.marker}')"
+if [ "${marker}" != "from-values-file" ]; then
+    echo "Expected values file marker override, got: ${marker}" >&2
+    exit 1
+fi
+
+log "Case 8: --reuse-values remains accepted on Helm 4"
+helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --target app-a --reuse-values --verbose --timeout 60
+
+log "Case 9: dry-run debug uses Helm 4 JSON output without mutating releases"
+before_a="$(helm --namespace "${NAMESPACE}" status app-a -o json)"
+dry_output="$(helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --dry-run --debug --timeout 60 2>&1)"
+printf '%s\n' "${dry_output}"
+assert_contains "${dry_output}" "--dry-run=client"
+after_a="$(helm --namespace "${NAMESPACE}" status app-a -o json)"
+if [ "${before_a}" != "${after_a}" ]; then
+    echo "Expected dry-run not to mutate app-a" >&2
+    exit 1
+fi
+
+invalid_target_output="$(expect_failure "Case 10: invalid target fails validation" \
+    helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --target not-a-chart --timeout 60)"
+assert_contains "${invalid_target_output}" "invalid targetted sub-chart"
+
+conflicting_flags_output="$(expect_failure "Case 11: conflicting target/exclude fails validation" \
+    helm --namespace "${NAMESPACE}" spray "${CHART_DIR}" --target app-a --exclude app-b --timeout 60)"
+assert_contains "${conflicting_flags_output}" "cannot use both --target and --exclude together"
+
+log "All Helm 4 integration tests passed in namespace ${NAMESPACE}"

--- a/scripts/helm4_smoke_test.sh
+++ b/scripts/helm4_smoke_test.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+set -eu
+
+CLUSTER_NAME="${CLUSTER_NAME:-spray-test}"
+NAMESPACE="${NAMESPACE:-spray-smoke}"
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/helm-spray-smoke.XXXXXX")"
+HELM_PLUGINS_DIR="${WORK_DIR}/helm-plugins"
+
+cleanup() {
+    rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required command: $1" >&2
+        exit 1
+    fi
+}
+
+require go
+require helm
+require kind
+require kubectl
+
+mkdir -p "${HELM_PLUGINS_DIR}/spray/bin"
+cd "${ROOT_DIR}"
+go build -o "${HELM_PLUGINS_DIR}/spray/bin/helm-spray" main.go
+cp plugin.yaml README.md LICENSE "${HELM_PLUGINS_DIR}/spray/"
+
+export HELM_PLUGINS="${HELM_PLUGINS_DIR}"
+
+if ! kind get clusters | grep -qx "${CLUSTER_NAME}"; then
+    kind create cluster --name "${CLUSTER_NAME}"
+fi
+
+kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1 || kubectl create namespace "${NAMESPACE}" >/dev/null
+
+mkdir -p "${WORK_DIR}/chart/charts/app-a/templates" "${WORK_DIR}/chart/charts/app-b/templates"
+
+cat > "${WORK_DIR}/chart/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: helm-spray-smoke
+version: 0.1.0
+dependencies:
+  - name: app-a
+    version: 0.1.0
+    repository: file://charts/app-a
+    condition: app-a.enabled
+  - name: app-b
+    version: 0.1.0
+    repository: file://charts/app-b
+    condition: app-b.enabled
+EOF
+
+cat > "${WORK_DIR}/chart/values.yaml" <<'EOF'
+app-a:
+  enabled: true
+  weight: 0
+app-b:
+  enabled: true
+  weight: 1
+EOF
+
+cat > "${WORK_DIR}/chart/charts/app-a/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: app-a
+version: 0.1.0
+appVersion: "1.0"
+EOF
+
+cat > "${WORK_DIR}/chart/charts/app-a/values.yaml" <<'EOF'
+enabled: true
+weight: 0
+EOF
+
+cat > "${WORK_DIR}/chart/charts/app-a/templates/configmap.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-a-smoke
+data:
+  app: app-a
+EOF
+
+cat > "${WORK_DIR}/chart/charts/app-b/Chart.yaml" <<'EOF'
+apiVersion: v2
+name: app-b
+version: 0.1.0
+appVersion: "1.0"
+EOF
+
+cat > "${WORK_DIR}/chart/charts/app-b/values.yaml" <<'EOF'
+enabled: true
+weight: 1
+EOF
+
+cat > "${WORK_DIR}/chart/charts/app-b/templates/configmap.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-b-smoke
+data:
+  app: app-b
+EOF
+
+helm dependency build "${WORK_DIR}/chart"
+helm --namespace "${NAMESPACE}" spray "${WORK_DIR}/chart" --verbose --timeout 60
+helm --namespace "${NAMESPACE}" spray "${WORK_DIR}/chart" --target app-a --verbose --timeout 60
+helm --namespace "${NAMESPACE}" spray "${WORK_DIR}/chart" --exclude app-b --verbose --timeout 60
+helm --namespace "${NAMESPACE}" spray "${WORK_DIR}/chart" --dry-run --debug --timeout 60
+
+helm --namespace "${NAMESPACE}" list
+kubectl --namespace "${NAMESPACE}" get configmap app-a-smoke app-b-smoke
+

--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -3,13 +3,28 @@
 # shellcheck disable=SC2002
 version="$(cat plugin.yaml | grep "version" | cut -d ' ' -f 2)"
 os=$(uname)
-echo "Downloading and installing spray v${version} for ${os}..."
+arch=$(uname -m)
+
+case "${arch}" in
+    x86_64|amd64)
+        arch="amd64"
+        ;;
+    arm64|aarch64)
+        arch="arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: ${arch}" >&2
+        exit 1
+        ;;
+esac
+
+echo "Downloading and installing spray v${version} for ${os}/${arch}..."
 
 url=""
 if [ "${os}" = "Linux" ] ; then
-    url="https://github.com/ThalesGroup/helm-spray/releases/download/v${version}/helm-spray-linux-amd64.tar.gz"
+    url="https://github.com/ThalesGroup/helm-spray/releases/download/v${version}/helm-spray-linux-${arch}.tar.gz"
 elif [ "${os}" = "Darwin" ] ; then
-   url="https://github.com/ThalesGroup/helm-spray/releases/download/v${version}/helm-spray-darwin-amd64.tar.gz"
+    url="https://github.com/ThalesGroup/helm-spray/releases/download/v${version}/helm-spray-darwin-${arch}.tar.gz"
 else
     url="https://github.com/ThalesGroup/helm-spray/releases/download/v${version}/helm-spray-windows-amd64.tar.gz"
 fi


### PR DESCRIPTION
## Summary

This PR modernizes the release build process and adds repeatable Helm 4 compatibility checks.

## Changes

- Build release artifacts with `CGO_ENABLED=0` for better Linux portability.
- Add release artifacts for:
  - `linux-amd64`
  - `linux-arm64`
  - `darwin-amd64`
  - `darwin-arm64`
  - `windows-amd64`
- Remove `go get -t -v ./...` from release builds.
- Add `make test`, `make build`, `make dist`, `make helm4-smoke`, and `make helm4-integration`.
- Add Helm 4 smoke and integration test scripts.
- Update dry-run handling to use `--dry-run=client`.
- Update plugin installer OS/architecture archive selection.
- Bump plugin version to `4.0.14`.
- Add changelog entry for `4.0.14`.

## Validation

Tested locally with:

```sh
make test
make build
make dist
make helm4-integration
docker run --rm -v "$PWD/_dist:/dist" alpine:3.20 sh -c 'tar -xzf /dist/helm-spray-linux-amd64.tar.gz -C /tmp && /tmp/bin/helm-spray --help >/dev/null && grep -q "version: 4.0.14" /tmp/plugin.yaml && echo linux-amd64-ok'